### PR TITLE
Fixed missing quotes from get_field string on line 264

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -261,7 +261,7 @@ function ign_get_header_image( $post_id = 0, $return_type = 'url', $attr = '' ) 
 		$post_id = $post->ID;
 	}
 
-	if ( get_field( 'no_image', $post_id ) ) {
+	if ( "get_field( 'no_image', $post_id )" ) {
 		return '';
 	}
 


### PR DESCRIPTION
Version 2.0 introduced an syntax error in the /inc/template-tags.php file on line 264