### PR TITLE
refactor: add ssl prompt in setup script

### DIFF
--- a/replace.config.js
+++ b/replace.config.js
@@ -70,7 +70,7 @@ const questions = [
    {
       type: 'confirm',
       name: 'ssl',
-      message: 'Does your server have an SSL?',
+      message: 'Does your local server have an SSL?',
    }
 ];
 

--- a/replace.config.js
+++ b/replace.config.js
@@ -66,6 +66,11 @@ const questions = [
       name: 'server',
       message: 'Development or Remote Url',
       initial: 'ignition.local'
+   },
+   {
+      type: 'confirm',
+      name: 'ssl',
+      message: 'Does your server have an SSL?',
    }
 ];
 
@@ -119,8 +124,19 @@ const questions = [
              files: './theme.config.json',
              dry: args['dry'] || false,
              verbose: true,
-             from: [/"name": ".*/g, /"slug": ".*/g, /"server": ".*/g],
-             to: [`"name": "${response.name}",`, `"slug": "${response.slug}",`, `"server": "${response.server}",`]
+             from: [
+               /"name": ".*/g,
+               /"slug": ".*/g,
+               /"server": ".*/g,
+               /"ssl": .*/g,
+            ]
+               ,
+             to: [
+               `"name": "${response.name}",`,
+               `"slug": "${response.slug}",`,
+               `"server": "${response.server}",`,
+               `"ssl": ${response.ssl},`
+            ]
           }
 
           try {

--- a/theme.config.json
+++ b/theme.config.json
@@ -2,6 +2,7 @@
   "name": "Ignition",
   "slug": "ignition",
   "server": "ignition.local",
+  "ssl": false,
   "google_fonts": [
     "Roboto:400,400i,700,700i",
     "Roboto Slab:400,700"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,7 +93,7 @@ module.exports = {
       new MiniCssExtractPlugin(),
       new BrowserSyncPlugin({
              host: themeConfig.server,
-             proxy: `https://${themeConfig.server}`,
+             proxy: `${themeConfig.ssl ? 'https' : 'http'}://${themeConfig.server}`,
              https: true,
              files: [
                 '**/*.php',


### PR DESCRIPTION
Allow the developer to specify if their local server is using an ssl or not. 

This resolves issue #18 