### PR TITLE
fix: navigation hover event

### DIFF
--- a/src/js/core/navigation_callbacks.js
+++ b/src/js/core/navigation_callbacks.js
@@ -33,6 +33,9 @@ export function toggleTopLevelVerticalMenu(menuItem, open = true) {
 //non on all top level submenus for click and hover
 export function toggleSubMenu(menuItem, open = true) {
    const subMenu = menuItem.querySelector('.sub-menu')
+   // Exit function if no subMenu is found.
+   if(!subMenu) return
+
    if (open) {
       //change to whatever you want ie: ignSlideDown...
       menuItem.classList.add('toggled-on')

--- a/src/js/core/setup.js
+++ b/src/js/core/setup.js
@@ -86,6 +86,9 @@ export function ignSlideUp(target, duration = .5) {
 export function ignSlide(direction = 'up', target, duration = .5) {
    return new Promise(function (resolve, reject) {
 
+      // Exit function if no target it falsey, as we depend on the target to run this function
+      if(!target) return
+
       if (target.dataset.slideTimer) {
          clearTimeout(parseInt(target.dataset.slideTimer))
          target.removeAttribute('slide-timer')


### PR DESCRIPTION
The toggleSubMenu function was recursively checking for sub menus. The function was still attempt to slide open the sub menu even when one didn't exist.